### PR TITLE
Bind Ctrl-h to Colour Picker. Fixes #2

### DIFF
--- a/quiet.py
+++ b/quiet.py
@@ -9,6 +9,7 @@ from tkinter import colorchooser
 class Menubar:
     
     def __init__(self, parent):
+        self._parent = parent
         font_specs = ('Droid Sans Fallback', 12)
 
         menubar = tk.Menu(parent.master, font=font_specs,
@@ -46,8 +47,11 @@ class Menubar:
         menubar.add_cascade(label='File', menu=file_dropdown)
         menubar.add_command(label='Settings', command=parent.open_settings_file)
         menubar.add_cascade(label='About', menu=about_dropdown)
-        menubar.add_command(label='Hex Colors')
+        menubar.add_command(label='Hex Colors', command=self.open_color_picker)
         menubar.add_command(label='Quiet Mode')
+
+    def open_color_picker(self):
+        return colorchooser.askcolor()[1]
 
     def about_message(self):
         box_title = 'About QuietTxt'
@@ -204,6 +208,16 @@ class QuietTxt:
         self.textarea.see(tk.INSERT)
         return 'break'
 
+    def apply_hex_color(self, key_event):
+        new_color = self.menubar.open_color_picker()
+        try:
+            sel_start = self.textarea.index(tk.SEL_FIRST)
+            sel_end = self.textarea.index(tk.SEL_LAST)
+            self.textarea.delete(sel_start, sel_end)
+            self.textarea.insert(sel_start, new_color)
+        except tk.TclError:
+            pass
+
     def bind_shortcuts(self, *args):
         self.textarea.bind('<Control-n>', self.new_file)
         self.textarea.bind('<Control-o>', self.open_file)
@@ -211,6 +225,7 @@ class QuietTxt:
         self.textarea.bind('<Control-S>', self.save_as)
         self.textarea.bind('<Control-b>', self.run)
         self.textarea.bind('<Control-a>', self.select_all_text)
+        self.textarea.bind('<Control-h>', self.apply_hex_color)
         self.textarea.bind('<Key>', self.statusbar.update_status)
 
 


### PR DESCRIPTION
# Description

No new dependencies. `tkinter.colorchooser` is now used (instead of merely imported).
There is the binding to the menu item (albeit with no use of the return value) and a binding to <kbd>Ctrl</kbd>+<kbd>h</kbd>, which can be used to modify the `settings.json`.

I noticed, that the last character gets cut off. My tkinter knowledge isn't good enough to tell, what I'm doing wrong here.
Also, for some reason, the first character before the selection is deleted.

## Fixes #2

Replace `issue_no` with the issue number which is fixed in this PR

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/avinashkranjan/Amazing-Python-Scripts/blob/master/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My change works and is relatively clean.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (I adjusted to the previous code-style, i.e no comments)
