### PR TITLE
Change fontsize by ctrl scroll

### DIFF
--- a/src/quiet.py
+++ b/src/quiet.py
@@ -142,7 +142,7 @@ class TextLineNumbers(tk.Canvas):
     def redraw(self, *args):
         '''redraw line numbers'''
         self.delete("all")
-        self.config(width=(self._parent.font_size * 2))
+        self.config(width=(self._parent.font_size * 3))
 
         i = self.textwidget.index("@0,0")
         while True :


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description

Font size will increase or decrease based when we do ctrl + scroll.
I have added event binders for scroll and ctrl button. I have a local variable for control key pressed status. And based on scroll direction I changed the font size.

## Fixes  #16  


## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/SethWalkeroo/Quiet-Text/blob/main/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Documentation Update

## Checklist:

- [x] My works and is relatively clean. 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
