### PR TITLE
added a function  to change the font-size with ctrl+moseWheel

### DIFF
--- a/src/quiet.py
+++ b/src/quiet.py
@@ -617,6 +617,25 @@ class QuietText(tk.Frame):
         if self.filename == 'settings.yaml':
             self.clear_and_replace_textarea()
 
+    # This is the new function to change the font size using ctrl+mousewheel
+    def scroll_font_size(self,event,*args):
+        with open('settings.yaml', 'r') as settings_json:
+            settings = yaml.load(settings_json)
+        fontSize = settings['font_size']
+        font_family = settings['font_family']
+        if event.delta == 120:
+            fontSize = str(int(fontSize)+2)
+        if event.delta == -120:
+            fontSize = str(int(fontSize)-2)
+            
+        settings['font_size'] = fontSize
+        font_style = tk_font.Font(family=font_family,size=fontSize)
+        # text_font = settings['text_font']
+        # font_style = tk_font.Font(family=text_font, size=fontSize)
+        self.textarea.configure(font=font_style)
+        with open("settings.yaml", "w") as settings_json:
+            yaml.dump(settings, settings_json)
+
 
     # control_l = 37
     # control_r = 109
@@ -646,11 +665,12 @@ class QuietText(tk.Frame):
         self.textarea.bind('<<Change>>', self._on_change)
         self.textarea.bind('<Configure>', self._on_change)
         self.textarea.bind('<Button-3>', self.show_click_menu)
-        self.textarea.bind('<MouseWheel>', self._on_mousewheel)
+        # self.textarea.bind('<MouseWheel>', self._on_mousewheel)
         self.textarea.bind('<Button-4>', self._on_linux_scroll_up)
         self.textarea.bind('<Button-5>', self._on_linux_scroll_down)
         self.textarea.bind('<KeyPress>', self._on_keydown)
         self.textarea.bind('<KeyRelease>', self._on_keyup)
+        self.textarea.bind('<Control-MouseWheel>', self.scroll_font_size)
 
 
 if __name__ == '__main__':

--- a/src/settings.yaml
+++ b/src/settings.yaml
@@ -1,7 +1,7 @@
 bg_color: '#38342b'
 bottom_spacing: '1'
 font_family: monospace
-font_size: 12
+font_size: '24'
 insertion_blink: 'false'
 menu_active_bg: '#38342b'
 menu_active_fg: '#fff'
@@ -11,4 +11,3 @@ padding_y: '5'
 tab_size: 4
 text_color: white
 top_spacing: '1'
-


### PR DESCRIPTION
#23 
# Description
added a function named scroll_font_size which increases the font size by 2 units, when ctrl+mouseWheelUp is perfomed and decreases font size by 2 units when ctrl+mouseWheelDown is performed.
please check this out and tell me if it satisfies your purpose, or please let me know of any change

## Fixes #23  

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/SethWalkeroo/Quiet-Text/blob/main/CONTRIBUTING.md)?

- [ ] Yes
- [ ] No

## Type of change

_Please delete options that are not relevant._

- [ #23 ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation Update

## Checklist:

- [ ] My works and is relatively clean. 
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
