### PR TITLE
bug() : Editor Scrolling when user zooms in or out

### DIFF
--- a/src/quiet.py
+++ b/src/quiet.py
@@ -199,6 +199,7 @@ class CustomText(tk.Text):
         tk.Text.__init__(self, *args, **kwargs)
 
         # create a proxy for the underlying widget
+        self.isControlPressed = False
         self._orig = self._w + '_orig'
         self.tk.call('rename', self._w, self._orig)
         self.tk.createcommand(self._w, self._proxy)
@@ -207,7 +208,14 @@ class CustomText(tk.Text):
         # let the actual widget perform the requested action
         try:
             cmd = (self._orig,) + args
-            result = self.tk.call(cmd)
+            result = ''
+            if not self.isControlPressed:
+                # if command is not present, execute the event
+                result = self.tk.call(cmd)
+            else:
+                # Suppress y-scroll and x-scroll when control is pressed
+                if args[0:2] not in [('yview', 'scroll'), ('xview', 'scroll')]:
+                    result = self.tk.call(cmd)
         except tk.TclError:
             result = ''
 
@@ -611,11 +619,13 @@ class QuietText(tk.Frame):
     def _on_keydown(self, event):
         if event.keycode in [37, 109, 262401, 270336, 262145]:
             self.control_key = True
+            self.textarea.isControlPressed = True
             self.textarea.configure()
 
     def _on_keyup(self, event):
         if event.keycode in [37, 109, 262401, 270336, 262145]:
             self.control_key = False
+            self.textarea.isControlPressed = False
 
     def bind_shortcuts(self, *args):
         self.textarea.bind('<Control-n>', self.new_file)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description

The scrolling was handled by the CustomText class and the event emitted during scroll is yscroll or xscroll. Unlike shortcuts, scrolling cannot be stopped by simply binding a shortcut. To suppress the scroll event when the control is pressed, we use an indicator variable in the CustomText class to check whether control key is pressed or not. If pressed then we exclude the scroll events like xscroll and yscroll.

## Fixes #23 

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/SethWalkeroo/Quiet-Text/blob/main/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation Update

## Checklist:

- [x] My works and is relatively clean. 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
