### PR TITLE
Add option of toggling linenumbers

### DIFF
--- a/src/quiet_app_launch.py
+++ b/src/quiet_app_launch.py
@@ -220,6 +220,10 @@ class QuietText(tk.Frame):
     def hide_status_bar(self, *args):
         self.statusbar.hide_status_bar()
 
+    # toggle the visibility of line numbers
+    def toggle_linenumbers(self, *args):
+        self.linenumbers.visible = not self.linenumbers.visible
+
     # setting up the editor title
     #Renames the window title bar to the name of the current file.
     def set_window_title(self, name=None):
@@ -529,6 +533,7 @@ class QuietText(tk.Frame):
         text.bind('<BackSpace>', self.backspace_situations)
         text.bind('<Enter>', self.autoindent_bracket)
         text.bind('<Alt_L>', self.hide_and_unhide_menubar)
+        text.bind('<Control-L>', self.toggle_linenumbers)
 
 
 if __name__ == '__main__':

--- a/src/quiet_linenumbers.py
+++ b/src/quiet_linenumbers.py
@@ -12,6 +12,9 @@ class TextLineNumbers(tk.Canvas):
 
     def redraw(self, *args):
         '''redraw line numbers'''
+        if not self.visible:
+            return
+
         self.delete('all')
         self.config(width=(self._parent.font_size * 3))
 
@@ -26,3 +29,17 @@ class TextLineNumbers(tk.Canvas):
                              font=(self._text_font, self._parent.font_size),
                              fill='#75715E')
             i = self.textwidget.index('%s+1line' % i)
+
+    @property
+    def visible(self):
+        return self.cget('state') == 'normal'
+
+    @visible.setter
+    def visible(self, visible):
+        self.config(state='normal' if visible else 'disabled')
+
+        if visible:
+            self.redraw()
+        else:
+            self.delete('all')
+            self.config(width=0)

--- a/src/quiet_menubar.py
+++ b/src/quiet_menubar.py
@@ -82,6 +82,10 @@ class Menubar:
 
         view_dropdown.add_command(label='Hide Status Bar',
                                   command=parent.hide_status_bar)
+        
+        view_dropdown.add_command(label='Toggle Line Numbers',
+                                  accelerator='Ctrl+Shift+L',
+                                  command=parent.toggle_linenumbers)
 
         view_dropdown.add_command(label='Enter Quiet Mode',
                                   accelerator='Ctrl+Q',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description

Add toggling of the linenumbers visibility from _View_ menu and _[Control-Shift-L]_ binding.
Feature was discussed in #69 

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/SethWalkeroo/Quiet-Text/blob/main/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My works and is relatively clean. 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
