### PR TITLE
Shift+Tab unindent multiple lines and single line

### DIFF
--- a/src/quiet_app_launch.py
+++ b/src/quiet_app_launch.py
@@ -541,13 +541,27 @@ class QuietText(tk.Frame):
     def tab_text(self, event):
         index = self.textarea.index("sel.first linestart")
         last = self.textarea.index("sel.last linestart")
+
         if last != index:
-            while self.textarea.compare(index,"<=", last):
-                self.textarea.insert(index, '\t')
-                index = self.textarea.index("%s + 1 line" % index)
+            if event.state == 8:
+                while self.textarea.compare(index,"<=", last):
+                    if len(self.textarea.get(index, 'end')) != 0:
+                        self.textarea.insert(index, '\t')
+                    index = self.textarea.index("%s + 1 line" % index)
+            else:
+                while self.textarea.compare(index,"<=", last):
+                    if self.textarea.get(index, 'end')[:1] == "\t":
+                        self.textarea.delete(index)
+                    index = self.textarea.index("%s + 1 line" % index)
         else:
-            index = self.textarea.index(tk.INSERT)
-            self.textarea.insert(index, '\t')
+            if event.state == 8:
+                index = self.textarea.index(tk.INSERT)
+                self.textarea.insert(index, '\t')
+            else:
+                index = self.textarea.index("insert linestart")
+                if self.textarea.get(index, 'end')[:1] == "\t":
+                    self.textarea.delete(index)
+
         return "break"
 
 
@@ -587,6 +601,7 @@ class QuietText(tk.Frame):
         text.bind('<Alt_L>', self.hide_and_unhide_menubar)
         text.bind('<Control-L>', self.toggle_linenumbers)
         text.bind('<KeyPress-Tab>', self.tab_text)
+        text.bind('<Shift-KeyPress-Tab>', self.tab_text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description

Now the user is able to unindent multiple or single lines using <kbd>Shift</kbd> + <kbd>Tab</kbd>.

Files changed:
1. *quiet_app_launch.py*

Functions updated:
1. *tab_text*

## Fixes (if any) #77  

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/SethWalkeroo/Quiet-Text/blob/main/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

_Please delete options that are not relevant._

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My works and is relatively clean. 
- [x] I have performed a self-review of my own code
